### PR TITLE
Fixes types

### DIFF
--- a/src/DI/ContainerBase.php
+++ b/src/DI/ContainerBase.php
@@ -13,6 +13,7 @@ use ReflectionClass, ReflectionException;
 use function array_key_exists, class_exists, interface_exists, is_array, is_string, is_subclass_of, uniqid, count;
 
 /**
+ * @phpstan-type ServiceDefinition class-string|array{factory?:class-string, factory_method?:callable, parameters?:array<string, mixed>, wiring?: class-string<object>, auto_wiring?: bool}
  * @implements ArrayAccess<string, object|class-string<object>|array{name: string, factory?: class-string<object>, auto_wiring?: bool, parameters?: array<string, mixed>, factory_method?: callable(mixed ...$parameters):object|null, instantiable: bool, factory_method?: callable(mixed ...$parameters):object|null}>
  */
 abstract class ContainerBase implements ArrayAccess, Countable
@@ -57,7 +58,7 @@ abstract class ContainerBase implements ArrayAccess, Countable
 		foreach ($config as $name => $service) if (is_string($service) || is_array($service))
 		{
 			/**
-			 * @var class-string<object>|array{factory?: class-string<object>, parameters?: array<string, mixed>, wiring?: class-string<object>, auto_wiring?: bool, factory_method?: callable(mixed ...$parameters):object|null} $service
+			 * @var ServiceDefinition $service
 			 */
 			$this[is_string($name) ? $name : uniqid('class-')] = $service;
 		}
@@ -285,8 +286,8 @@ abstract class ContainerBase implements ArrayAccess, Countable
 
 
 	/**
-	 * @param array-key $offset
-	 * @param class-string<object>|array{factory?: class-string<object>, parameters?: array<string, mixed>, wiring?: class-string<object>, auto_wiring?: bool, factory_method?: callable(mixed ...$parameters):object|null} $value
+	 * @param array-key $offset The service id
+	 * @param ServiceDefinition $value The service definition.
 	 * @throws AutoWiringException|InvalidStateException
 	 */
 	public function offsetSet($offset, $value): void

--- a/src/Event/Repository/AsynchronousDatabase.php
+++ b/src/Event/Repository/AsynchronousDatabase.php
@@ -29,7 +29,7 @@ class AsynchronousDatabase implements Asynchronous
 		$this->db->execute('START TRANSACTION');
 
 		$records = $this->db->execute(
-			$this->db->prepare("SELECT * FROM `{$this->db->table('bulkgate_module')}` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT %s FOR UPDATE", $limit)
+			"SELECT * FROM `{$this->db->table('bulkgate_module')}` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT {$this->db->escape((string) $limit)} FOR UPDATE"
 		);
 
 		if ($records !== null)

--- a/src/Event/Repository/AsynchronousDatabase.php
+++ b/src/Event/Repository/AsynchronousDatabase.php
@@ -28,8 +28,13 @@ class AsynchronousDatabase implements Asynchronous
 
 		$this->db->execute('START TRANSACTION');
 
+		/**
+		 * @var literal-string $limit
+		 */
+		$limit = strval($limit);
+
 		$records = $this->db->execute(
-			"SELECT * FROM `{$this->db->table('bulkgate_module')}` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT {$this->db->escape((string) $limit)} FOR UPDATE"
+			"SELECT * FROM `{$this->db->table('bulkgate_module')}` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT $limit FOR UPDATE"
 		);
 
 		if ($records !== null)

--- a/tests/Event/Repository/AsynchronousDatabaseTest.phpt
+++ b/tests/Event/Repository/AsynchronousDatabaseTest.phpt
@@ -21,8 +21,8 @@ class AsynchronousDatabaseTest extends TestCase
 
 		$db->shouldReceive('table')->with('bulkgate_module')->times(3)->andReturn('bulkgate_module');
 		$db->shouldReceive('execute')->with('START TRANSACTION')->once()->ordered();
-		$db->shouldReceive('prepare')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT %s FOR UPDATE", 2)->once()->ordered()->andReturn('SQL1');
-		$db->shouldReceive('execute')->with('SQL1')->once()->ordered()->andReturn(new ResultCollection([
+		$db->shouldReceive('escape')->with('2')->once()->ordered()->andReturn(2);
+		$db->shouldReceive('execute')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT 2 FOR UPDATE")->once()->ordered()->andReturn(new ResultCollection([
 			['key' => 'task1', 'value' => '{"category": "test", "endpoint": "endpoint1", "variables": {"key": "value"}}', 'datetime' => '456', 'order' => '0'],
 			['key' => 'task2', 'value' => '{"category": "test", "endpoint": "endpoint2", "variables": {"key2": "value2"}}', 'datetime' => 456, 'order' => 0],
 		]));
@@ -50,8 +50,8 @@ class AsynchronousDatabaseTest extends TestCase
 
 		$db->shouldReceive('table')->once()->andReturn('bulkgate_module');
 		$db->shouldReceive('execute')->with('START TRANSACTION')->once()->ordered();
-		$db->shouldReceive('prepare')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT %s FOR UPDATE", 2)->once()->ordered()->andReturn('SQL1');
-		$db->shouldReceive('execute')->with('SQL1')->once()->ordered()->andReturnNull();
+		$db->shouldReceive('escape')->with('2')->once()->ordered()->andReturn(2);
+		$db->shouldReceive('execute')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT 2 FOR UPDATE")->once()->ordered()->andReturnNull();
 		$db->shouldReceive('execute')->with('ROLLBACK')->once()->ordered();
 
 		$asynchronousDatabase = new AsynchronousDatabase($db);

--- a/tests/Event/Repository/AsynchronousDatabaseTest.phpt
+++ b/tests/Event/Repository/AsynchronousDatabaseTest.phpt
@@ -21,7 +21,6 @@ class AsynchronousDatabaseTest extends TestCase
 
 		$db->shouldReceive('table')->with('bulkgate_module')->times(3)->andReturn('bulkgate_module');
 		$db->shouldReceive('execute')->with('START TRANSACTION')->once()->ordered();
-		$db->shouldReceive('escape')->with('2')->once()->ordered()->andReturn(2);
 		$db->shouldReceive('execute')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT 2 FOR UPDATE")->once()->ordered()->andReturn(new ResultCollection([
 			['key' => 'task1', 'value' => '{"category": "test", "endpoint": "endpoint1", "variables": {"key": "value"}}', 'datetime' => '456', 'order' => '0'],
 			['key' => 'task2', 'value' => '{"category": "test", "endpoint": "endpoint2", "variables": {"key2": "value2"}}', 'datetime' => 456, 'order' => 0],
@@ -50,7 +49,6 @@ class AsynchronousDatabaseTest extends TestCase
 
 		$db->shouldReceive('table')->once()->andReturn('bulkgate_module');
 		$db->shouldReceive('execute')->with('START TRANSACTION')->once()->ordered();
-		$db->shouldReceive('escape')->with('2')->once()->ordered()->andReturn(2);
 		$db->shouldReceive('execute')->with("SELECT * FROM `bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT 2 FOR UPDATE")->once()->ordered()->andReturnNull();
 		$db->shouldReceive('execute')->with('ROLLBACK')->once()->ordered();
 


### PR DESCRIPTION
Odstraňuji volání metody prepare, která v implementaci prestashopu nahrazuje %s za ?. Ve vyslednem sql dotazu dochazelo k syntax erroru.

```sql
SELECT * FROM `ps_bulkgate_module` WHERE `scope` = 'asynchronous' AND `order` = 0 LIMIT ? FOR UPDATE
```